### PR TITLE
Removed differential elements on Patient

### DIFF
--- a/input/resources/StructureDefinition-profile-SignalPatient.json
+++ b/input/resources/StructureDefinition-profile-SignalPatient.json
@@ -16,26 +16,6 @@
   "differential": {
     "element": [
       {
-        "id": "Patient.extension:ethnicity",
-        "path": "Patient.extension",
-        "sliceName": "ethnicity"
-      },
-      {
-        "id": "Patient.extension:ethnicity.extension",
-        "path": "Patient.extension.extension",
-        "min": 1
-      },
-      {
-        "id": "Patient.extension:tribalAffiliation",
-        "path": "Patient.extension",
-        "sliceName": "tribalAffiliation"
-      },
-      {
-        "id": "Patient.extension:tribalAffiliation.extension",
-        "path": "Patient.extension.extension",
-        "min": 1
-      },
-      {
         "id": "Patient.extension:adoptionInfo",
         "path": "Patient.extension",
         "sliceName": "adoptionInfo",


### PR DESCRIPTION
The differential elements crept into our code because of running Forge validations, removing them as they are covered as part of US core Patient profile.